### PR TITLE
feature/stop-inventing-hyperlinks

### DIFF
--- a/frontend/src/logic/ai3.ts
+++ b/frontend/src/logic/ai3.ts
@@ -104,9 +104,8 @@ export const getLlmResponse = async (messages: Message[]) => {
   You are a UK civil servant. 
   If you see a word starting with "@" search for a tool by that name and use it. 
   Always cite any responses from tools to support answer, e.g. provide:
-  - source
+  - source, i.e. link or title
   - quotes
-  - links
   - etc
   Reply in British English.
   `


### PR DESCRIPTION
## context

As a User I want the LLM to display file titles rather than inventing non existent hyper links so that I am not missled