### PR TITLE
DRAFT: Pass Keycloak token to MCP servers

### DIFF
--- a/frontend/src/logic/ai3.ts
+++ b/frontend/src/logic/ai3.ts
@@ -56,7 +56,7 @@ const MCP_SERVERS = (() => {
 console.log('MCP Servers: ', MCP_SERVERS)
 
 
-export const getLlmResponse = async (messages: Message[]) => {
+export const getLlmResponse = async (messages: Message[], authToken: string) => {
 
   const agentModel = new AzureChatOpenAI({
     openAIApiKey: process.env['AZURE_OPENAI_API_KEY'],
@@ -71,6 +71,9 @@ export const getLlmResponse = async (messages: Message[]) => {
     const serverHeaders: any = {}
     if (mcpServer.accessToken) {
       serverHeaders['x-external-access-token'] = mcpServer.accessToken
+    }
+    if (authToken) {
+      serverHeaders['x_amzn_oidc_accesstoken'] = authToken
     }
     try {
       const transport = new SSEClientTransport(new URL(mcpServer.url), {

--- a/frontend/src/pages/post-message.ts
+++ b/frontend/src/pages/post-message.ts
@@ -30,7 +30,7 @@ export async function POST({ request, redirect, session }) {
   // get LLM response
   let llmResponse
   if (userPrompt) {
-    llmResponse = await getLlmResponse(messages)
+    llmResponse = await getLlmResponse(messages, request.headers.get('x-amzn-oidc-accesstoken'))
   }
 
   // add LLM response to session data


### PR DESCRIPTION
A small update to pass the Keycloak auth token to MCP servers in the header.

Don't merge until the Streamable connection with Caddy is working in main.