### PR TITLE
Apply visual tweaks and improve HTML template clarity

### DIFF
--- a/frontend/src/logic/ai3.ts
+++ b/frontend/src/logic/ai3.ts
@@ -15,7 +15,8 @@ export type Message = {
   type: 'user' | 'llm'
   response: {
     content: string,
-    tools?: {}[]
+    tools?: {}[],
+    tool_calls: [],
   }
 }
 

--- a/frontend/src/logic/get-tools.ts
+++ b/frontend/src/logic/get-tools.ts
@@ -3,11 +3,21 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { loadMcpTools } from '@langchain/mcp-adapters';
 import type { MCP_SERVER } from './get-servers';
+import type { StructuredToolInterface, ToolInputSchemaBase } from '@langchain/core/tools';
+
+
+export type Tool = StructuredToolInterface<
+  ToolInputSchemaBase,
+  any,
+  any
+> & {
+  serverName: string
+}
 
 
 export const getTools = async (servers: MCP_SERVER[], authToken: string ) => {
 
-  let mcpTools = [];
+  let mcpTools: Tool[] = [];
   let serversWithFailedConnections = [];
 
   for (const mcpServer of servers) {
@@ -59,7 +69,7 @@ export const getTools = async (servers: MCP_SERVER[], authToken: string ) => {
         console.log("Connected using SSE transport");
       }
 
-      const serverMcpTools = await loadMcpTools(mcpServer.url, client);
+      const serverMcpTools = (await loadMcpTools(mcpServer.url, client) as Tool[]);
       serverMcpTools.forEach((tool) => {
         tool.serverName = mcpServer.name;
       });

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -4,10 +4,20 @@ import LitWrapper from '../components/lit-wrapper.astro';
 import type { Message } from '../logic/ai3.ts';
 import { mcpServers } from '../logic/get-servers.ts';
 import { getTools } from '../logic/get-tools.ts';
+import type { Tool } from '../logic/get-tools.ts';
 
 let messages: Message[] | undefined = await Astro.session?.get('messages');
 
 const { mcpTools, serversWithFailedConnections } = await getTools(mcpServers, Astro.request.headers.get('x-amzn-oidc-accesstoken') || '');
+
+// create toolList to make it easier to reference tools for a particular server in the template
+let toolList: { [toolName: string]: Tool[] } = {};
+mcpTools.forEach((tool) => {
+  if (!toolList[tool.serverName]) {
+    toolList[tool.serverName] = [];
+  }
+  toolList[tool.serverName].push(tool);
+});
 
 ---
 
@@ -38,19 +48,19 @@ const { mcpTools, serversWithFailedConnections } = await getTools(mcpServers, As
                       { serversWithFailedConnections.includes(server.name) && 
                         <strong class="govuk-tag govuk-tag--red govuk-!-padding-left-1 govuk-!-padding-right-1 govuk-!-padding-top-0"><span class="govuk-body-xs">Error</span></strong>
                       }
-                      { !serversWithFailedConnections.includes(server.name) && mcpTools.filter((tool) => tool.serverName === server.name).length === 0 &&
+                      { !serversWithFailedConnections.includes(server.name) && toolList[server.name].length === 0 &&
                         <strong class="govuk-tag govuk-tag--red govuk-!-padding-left-1 govuk-!-padding-right-1 govuk-!-padding-top-0"><span class="govuk-body-xs">No tools found</span></strong>
                       }
                     </label>
-                    { !serversWithFailedConnections.includes(server.name) && mcpTools.filter((tool) => tool.serverName === server.name).length > 0 &&
+                    { !serversWithFailedConnections.includes(server.name) && toolList[server.name].length > 0 &&
                       <div id={'tool-hint-' + server.name } class="tool-selector__tools govuk-hint govuk-checkboxes__hint govuk-!-margin-top-1 govuk-!-padding-0" style="font-size: 1rem;">
                         <details class="govuk-details govuk-!-margin-bottom-0">
                           <summary class="govuk-details__summary">
-                            <span class="govuk-details__summary-text govuk-body-xs govuk-!-font-weight-bold">Tools</span>
+                            <span class="govuk-details__summary-text govuk-body-xs govuk-!-font-weight-bold">Tools</span><span class="govuk-body-xs"> ({ toolList[server.name].length })</span>
                           </summary>
                           <div class="govuk-details__text">
                             <ul class="govuk-list govuk-!-margin-bottom-0">
-                              { mcpTools.filter((tool) => tool.serverName === server.name).map((tool) =>
+                              { toolList[server.name].map((tool) =>
                                 <li class="govuk-body-xs govuk-!-margin-top-2">
                                   <strong class="govuk-!-display-block js-tool">{ tool.name }:</strong>
                                   { tool.description }
@@ -123,7 +133,9 @@ const { mcpTools, serversWithFailedConnections } = await getTools(mcpServers, As
     let container = document.querySelector('#message-container') as HTMLElement
     form.addEventListener('submit', (evt) => {
       evt.preventDefault()
-      const formData = new URLSearchParams(new FormData(form)).toString()
+
+      const record = Object.fromEntries(new FormData(form).entries()) as Record<string, string>
+      const formData = new URLSearchParams(record).toString()
 
       // set up new message
       let messageBoxUser = document.createElement('message-box')
@@ -172,12 +184,7 @@ const { mcpTools, serversWithFailedConnections } = await getTools(mcpServers, As
     font-family: 'Inter', sans-serif;
 
     li {
-      border: 1px solid #b1b4b6;
-      border-top-width: 0;
       padding: 7px !important;
-    }
-    li:first-child {
-      border-top-width: 1px;
     }
     li:nth-child(odd) {
       background-color: #f3f2f1;


### PR DESCRIPTION
## Changes

* Remove border from `@tool` autocomplete list
* Add number of tools available next to each MCP server
* Create a `toolList` variable to simplify the HTML template (so we don't have to filter each time)
* Improve typing
