### PR TITLE
Support local dev in Caddy via docker-compose

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -3,10 +3,20 @@ import { defineConfig } from 'astro/config';
 
 import node from '@astrojs/node';
 
+let port;
+
+if (!process.env.GOVAI_PORT) {
+  port = 4321;
+} else {
+  port = parseInt(process.env.GOVAI_PORT);
+}
+
 // https://astro.build/config
 export default defineConfig({
+  server: { port: port, host: true },
   adapter: node({
     mode: 'standalone'
   }),
   output: 'server'
 });
+


### PR DESCRIPTION
In order to support a local client being swapped in for a stock client and running in dev mode, we need to run this server on the same port as the stock client, i.e. 8081. This is because the Caddy docker-compose setup for auth expects the different services to be at stable ports. There is a corresponding change in Caddy to support this.