### PR TITLE
Give access to authenticated users with any role

### DIFF
--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -15,9 +15,15 @@ export async function isAuthorisedUser(header: string): Promise<boolean> {
     return false;
   }
 
+  /*
+  Checks the user has the required role for this app
+  (bypassing for now, as any role is allowed for Gov AI Client)
   return parsedToken.roles.some(role => 
     role === process.env.REPO || role === "local-testing"
   )
+  */
+  return parsedToken.roles;
+
 }
 
 async function parseAuthToken(header: string) {
@@ -46,7 +52,7 @@ async function parseAuthToken(header: string) {
   }
 
   let roles = tokenContent.realm_access.roles || [];
-  console.debug(`Roles found for user ${email}: ${roles}`);
+  //console.debug(`Roles found for user ${email}: ${roles}`);
   return {
     email,
     roles,


### PR DESCRIPTION
We currently check for the `gov-ai-client` role before giving users access.

We now want to allow any authenticated user to have access.

This PR is to give access to any users who have at least one role, but it doesn't specifically have to be `gov-ai-client`.

I've commented out rather than removed so it's clear what's going on, and helps prevent any issues if this gets copied to another app in the future.