### PR TITLE
Tool call updates

### DIFF
--- a/frontend/src/components/tool-info.mjs
+++ b/frontend/src/components/tool-info.mjs
@@ -30,12 +30,8 @@ const ToolInfo = class extends LitElement {
           <img src="${'/server-logos/' + this.server.toLowerCase().replaceAll(' ', '_') + '.png'}" alt=""/>
         </span>
         <span class="tool-info__text" aria-live="polite">
-          ${this.inUse === 'true' ? html`
-            <span class="govuk-body-xs govuk-!-margin-bottom-0">Using the <strong>${this.name}</strong> tool</span>
-            <span class="govuk-body-xs govuk-!-margin-bottom-0">From the <strong>${this.server}</strong> plugin</span>
-          `: html`
-            <span class="govuk-body-xs govuk-!-margin-bottom-0">View the <strong>${this.name}</strong> tool</span>
-          `}
+          <span class="govuk-body-xs govuk-!-margin-bottom-0">${this.inUse === 'true' ? 'Using' : 'View'} the <strong>${this.name}</strong> tool</span>
+          <span class="govuk-body-xs govuk-!-margin-bottom-0">From the <strong>${this.server}</strong> plugin</span>
         </span>
       </button>
       <div class="tool-info__expandable" id="tool-${this.ref}">

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -321,17 +321,19 @@ let messages: Message[] | undefined = await Astro.session?.get('messages');
     button::after {
       top: 10px;
     }
-    .tool-info__icon::after {
-      animation: spin 1.2s linear infinite;
-      border: 2px solid #ccc;
-      border-top: 2px solid black;
-      border-radius: 50%;
-      content: ' ';
-      display: block;
-      height: calc(var(--size) + 4px);
-      position: absolute;
-      top: -4px;
-      width: calc(var(--size) + 4px);
+    @media (prefers-reduced-motion: no-preference) {
+      .tool-info__icon::after {
+        animation: spin 1.2s linear infinite;
+        border: 2px solid #ccc;
+        border-top: 2px solid black;
+        border-radius: 50%;
+        content: ' ';
+        display: block;
+        height: calc(var(--size) + 4px);
+        position: absolute;
+        top: -4px;
+        width: calc(var(--size) + 4px);
+      }
     }
   }
   @keyframes spin {


### PR DESCRIPTION
A couple of small updates:

* Only show the tool-call spinner if users haven't requested reduced animations (in their OS settings)

* Always show the server name in the tool calls, e.g.
<img width="200" alt="" src="https://github.com/user-attachments/assets/c82db487-8c79-48ba-980f-23571a07a0c2" />
(it previously disappeared once complete)
