### PR TITLE
Clear session data if a different user accesses from same device

### DIFF
--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -2,31 +2,7 @@ import 'dotenv/config';
 import { jwtVerify, decodeJwt, errors, importSPKI } from 'jose';
 
 
-export async function isAuthorisedUser(header: string): Promise<boolean> {
-  if (!process.env.REPO) {
-    console.error('REPO environment variable not set');
-    return false;
-  }
-
-  const parsedToken = await parseAuthToken(header);
-
-  if (!parsedToken) {
-    console.error('No token found for user');
-    return false;
-  }
-
-  /*
-   *Checks the user has the required role for this app
-   *(bypassing for now, as any role is allowed for Gov AI Client)
-   *return parsedToken.roles.some(role =>
-   *  role === process.env.REPO || role === "local-testing"
-   *)
-   */
-  return parsedToken.roles;
-
-}
-
-async function parseAuthToken(header: string) {
+export async function parseAuthToken(header: string) {
   if (!header) {
     console.error('No auth token provided to parse');
     return null;

--- a/frontend/src/layouts/Chat.astro
+++ b/frontend/src/layouts/Chat.astro
@@ -7,9 +7,6 @@ import LogoAnimation from '../components/LogoAnimation.astro';
 import type { Message } from '../logic/ai3.ts';
 import { mcpServers } from '../logic/get-servers.ts';
 
-// initialise session cookie if it doesn't already exist (required for SSE)
-Astro.session?.set('now', Date.now());
-
 // Scoped pages
 const { scope } = Astro.params;
 const singleServer = mcpServers.find((server) => server.name.toLowerCase() === scope?.toLowerCase());


### PR DESCRIPTION
We want to avoid a situation where a user's session data is available to a different user on the same device.

I first thought about prepending the user's email address to each session data key, but this is cumbersome and could be missed in the future.

So with this proposed approach we check if it's the same user in the middleware. If not, then we clear the existing session data.