### PR TITLE
Tweaks2

### DIFF
--- a/frontend/src/components/SidePanel.astro
+++ b/frontend/src/components/SidePanel.astro
@@ -6,7 +6,7 @@ const selectedServer = Astro.props.selectedServer;
 
 <side-panel>
 
-  <header class="sidepanel bg-background-grey border-r-1 border-border-grey fixed flex flex-col h-screen justify-between overflow-hidden top-0 transition-width w-10 z-10 [.ready>&]:motion-safe:duration-500 md:w-14 lg:sticky">
+  <header class="sidepanel bg-background-grey border-r-1 border-border-grey fixed flex flex-col h-screen justify-between max-h-screen overflow-x-hidden overflow-y-auto top-0 transition-width w-10 z-10 [.ready>&]:motion-safe:duration-500 md:w-14 lg:sticky">
     
     <div class="border-b-1 border-border-grey cursor-pointer flex gap-1 items-center justify-between px-1 py-3 w-60 z-20 md:px-2">
       <div class="flex gap-1 items-center">
@@ -48,7 +48,7 @@ const selectedServer = Astro.props.selectedServer;
             )}
           </ul>
         </div>
-        <a class="flex gap-3 items-start no-underline! px-[3px] rounded-sm md:px-2" href="/chat-history">
+        <a class="flex gap-3 items-start my-2 no-underline! px-[3px] rounded-sm md:px-2" href="/chat-history">
           <span class="rounded-full">
             <img class="h-4 md:h-5" src="/icons/history.svg" alt="Chat history" />
           </span>

--- a/frontend/src/components/message-box.mjs
+++ b/frontend/src/components/message-box.mjs
@@ -63,7 +63,7 @@ export class MessageBox extends LitElement {
           <h2 class="govuk-visually-hidden">AI:</h2>
           
           ${this.toolCalls.map((tool, toolIndex) => html`
-            <tool-info name=${tool.name} server=${tool.server} entries=${JSON.stringify(tool.args)} in-use=${toolIndex + 1 < this.toolCalls.length || this.content.length ? 'false' : 'true'} ref=${this.messageIndex + '-' + toolIndex}></tool-info>
+            <tool-info name=${tool.name} server=${tool.server} entries=${JSON.stringify(tool.args)} in-use=${toolIndex + 1 < this.toolCalls.length || !this.streamingInProgress ? 'false' : 'true'} ref=${this.messageIndex + '-' + toolIndex}></tool-info>
           `)}
 
           ${this.content ? html`

--- a/tests/tests.spec.ts
+++ b/tests/tests.spec.ts
@@ -31,6 +31,8 @@ const testAccessibility = async (page: Page) => {
 
 test('Basic prompt-related tasks', async ({ page }) => {
 
+  await page.locator('#model-selector').selectOption('Fast');
+
   await sendPrompt('What is the capital of Norway?', page);
 
   // check the response is shown
@@ -62,6 +64,24 @@ test('Basic prompt-related tasks', async ({ page }) => {
   await page.waitForLoadState('domcontentloaded');
   expect(await page.locator('.message-box--llm').count()).toEqual(0);
  
+});
+
+
+test('Chat history', async ({ page, browserName }) => {
+
+  await page.locator('a:has-text("Chat history")').click();
+
+  await expect(page.locator('h1')).toContainText('Chat history');
+  await expect(page.locator('main li a').first()).toContainText('What is the capital of Norway?');
+
+  await testAccessibility(page);
+
+  const count1 = await page.locator('main li').count();
+  await page.locator('main li button:has-text("Delete")').first().click();
+
+  const count2 = await page.locator('main li').count();
+  expect (count2).toEqual(count1 - 1);
+
 });
 
 
@@ -116,6 +136,8 @@ test('Message input functionality', async ({ page }) => {
 
 
 test('Copy to clipboard', async ({ page, browserName }) => {
+
+  await page.locator('#model-selector').selectOption('Fast');
 
   await sendPrompt('What is the capital of Norway?', page);
   await waitForResponse(page);


### PR DESCRIPTION
A few tweaks/improvements:

* Tidy-up the tool animation. This was set to only show until the response started appearing. But in fast-mode Claude responds before and after the tool call, so I've set this to animate until either the response is complete, or the next tool has been called.

* The sidebar needs to allow scrolling if the content height is greater than the container height. It does now.

* Sped up a couple of the Playwright tests by switching to fast-mode.

* Added tests for chat-history.