### PR TITLE
Bugfix/various tweaks

### DIFF
--- a/frontend/src/components/SidePanel.astro
+++ b/frontend/src/components/SidePanel.astro
@@ -8,6 +8,15 @@ const selectedServer = Astro.props.selectedServer;
 
 const caddyServers = mcpServers.filter((server) => server.isCaddy);
 
+const caddyUrl = (() => {
+  if (process.env.ENVIRONMENT?.toLowerCase() === 'dev' || process.env.ENVIRONMENT?.toLowerCase() === 'preprod') {
+    return `https://caddy-${process.env.ENVIRONMENT.toLocaleLowerCase()}.ai.cabinetoffice.gov.uk`;
+  } else if (process.env.ENVIRONMENT?.toLowerCase() === 'local') {
+    return 'http://localhost:4322';
+  }
+  return 'https://caddy.ai.cabinetoffice.gov.uk';
+})();
+
 ---
 
 <side-panel>
@@ -30,7 +39,7 @@ const caddyServers = mcpServers.filter((server) => server.isCaddy);
     <nav class="sidepanel__content grow px-2 py-3 w-60">
       <div class="flex flex-col h-full justify-between">
         <div>
-          { caddyServers.length &&
+          { caddyServers.length > 0 &&
             <>
               <h2 class="sidepanel__hide-on-collapse float-left font-bold mt-1 pl-[3px] text-md md:pl-2">Collections</h2>
               <ul class="mt-7">
@@ -43,7 +52,7 @@ const caddyServers = mcpServers.filter((server) => server.isCaddy);
           <h2 class="sidepanel__hide-on-collapse float-left font-bold mt-1 pl-[3px] text-md md:pl-2">Tools</h2>
           <ul class="mt-7">
             { mcpServers.filter((mcpServer) => !mcpServer.isCaddy).map((mcpServer) =>
-              <SidePanelServer mcpServer={ mcpServer } selectedServer={ selectedServer } />
+              <SidePanelServer mcpServer={ mcpServer } selectedServer={ selectedServer } hasLogo="true" />
             )}
           </ul>
           <div class="px-[2px] pb-5 pt-2">
@@ -62,12 +71,13 @@ const caddyServers = mcpServers.filter((server) => server.isCaddy);
             </span>
             <span class="sidepanel__hide-on-collapse underline underline-offset-6 hover:decoration-3" aria-hidden="true">Chat history</span>
           </a>
-          { caddyServers.length &&
-            <a class="flex gap-3 items-start mb-2 mt-4 no-underline! px-[3px] rounded-sm md:px-2" href="https://caddy.ai.cabinetoffice.gov.uk/">
+          { caddyServers.length > 0 &&
+            <a class="flex gap-3 items-start mb-2 mt-4 no-underline! px-[3px] rounded-sm md:px-2" href={ caddyUrl } target="_blank" rel="noreferrer noopener">
               <span class="rounded-full">
                 <img class="h-4 md:h-5" src="/icons/collections.svg" alt="Manage collections" />
               </span>
               <span class="sidepanel__hide-on-collapse underline underline-offset-6 hover:decoration-3" aria-hidden="true">Manage collections</span>
+              <span class="sr-only"> (opens in new tab)</span>
             </a>
           }
         </div>

--- a/frontend/src/components/SidePanelServer.astro
+++ b/frontend/src/components/SidePanelServer.astro
@@ -3,13 +3,17 @@ import type { MCP_SERVER } from '../logic/get-servers';
 
 const mcpServer: MCP_SERVER = Astro.props.mcpServer;
 const selectedServer = Astro.props.selectedServer;
+const hasLogo = Astro.props.hasLogo;
+
 ---
 
 <li class="px-[2px] py-2">
   <a class="flex gap-3 items-start no-underline! rounded-sm" href={ '/scoped/' + mcpServer.name.toLowerCase() } aria-current={ mcpServer.name === selectedServer ? 'page' : undefined }>
     <span class="bg-black border-2 border-black border-solid decoration-none flex h-5 items-center justify-center relative rounded-full text-sm text-white w-5 data-current:border-pink md:h-6 md:ml-[6px] md:w-6" data-current={ mcpServer.name === selectedServer ? 'page' : undefined }>
       <span class="no-underline" aria-hidden="true">{ mcpServer.name[0].toUpperCase() }</span>
-      <img class="absolute" src={ '/server-logos/black/' + mcpServer.name.toLowerCase().replaceAll(' ', '_') + '.png' } alt="" />
+      { hasLogo && 
+        <img class="absolute" src={ '/server-logos/black/' + mcpServer.name.toLowerCase().replaceAll(' ', '_') + '.png' } alt="" />
+      }
       <span class="sr-only">{ mcpServer.name }</span>
     </span>
     <span class="sidepanel__hide-on-collapse border-b-1 mt-[2px] hover:border-b-3" aria-hidden="true">{ mcpServer.name }</span>

--- a/frontend/src/components/markdown-converter.mjs
+++ b/frontend/src/components/markdown-converter.mjs
@@ -99,7 +99,7 @@ const MarkdownConverter = class extends LitElement {
     this.querySelectorAll('a:not([target="_blank"])').forEach((link) => {
       link.setAttribute('target', '_blank');
       link.setAttribute('rel', 'noreferrer noopener');
-      link.innerHTML += ' <span class="govuk-visually-hidden">(opens in new tab)</span>';
+      link.innerHTML += ' <span class="sr-only top-0 -left-[1000px]">(opens in new tab)</span>';
     });
   }
 

--- a/frontend/src/pages/chat-history.astro
+++ b/frontend/src/pages/chat-history.astro
@@ -26,7 +26,7 @@ const timeOptions: Intl.DateTimeFormatOptions = {
     { chats.map((chat) =>
       <li class="border-1 border-border-grey border-solid flex gap-2 justify-between mt-3 px-3 py-2 rounded-md">
         <span class="flex flex-col lg:flex-row lg:gap-2">
-          <a class="break-all underline-offset-4 hover:decoration-3" href={ (chat.scope === 'all' ? '/' : '/scoped/' + chat.scope) + '?chatid=' + chat.id }>{ chat.title }</a>
+          <a class="break-all underline-offset-4 hover:decoration-3" href={ (chat.scope === 'all' ? '/mixed-sources' : '/scoped/' + chat.scope) + '?chatid=' + chat.id }>{ chat.title }</a>
           <span class="flex flex-col sm:flex-row sm:gap-2">
             { chat.scope !== 'all' &&
               <span class="gap-1 inline-flex items-center text-text-secondary">


### PR DESCRIPTION
Various tweaks/fixes:

* Update `sr-only` links so they don't cause the page height to over-expand
* Open the Caddy sidebar link in a new tab, and in the correct environment
* Don't attempt to load icons for the Caddy collections in the sidebar, as they don't exist
* Fix broken mixed-sources links in the chat history
